### PR TITLE
Fix fastboot support

### DIFF
--- a/addon/instance-initializers/router-service.js
+++ b/addon/instance-initializers/router-service.js
@@ -10,15 +10,19 @@ export function initialize(appInstance) {
 
   let { application } = appInstance;
   let fullName = 'service:router';
-  let router = lookupSource.lookup('router:main');
-  let registerOptions = { singleton: true, instantiate: false };
+  
+  let registerSource;
+
   // use application for ember 1.13
   if (application.hasRegistration) {
-    appInstance.register(fullName, router, registerOptions);
+    registerSource = appInstance;
   } else {
-    application.register(fullName, router, registerOptions);
+    registerSource = application;
   }
 
+  let router = lookupSource.lookup('router:main');
+
+  registerSource.register(fullName, router, { singleton: true, instantiate: false });
 }
 
 export default {

--- a/addon/instance-initializers/router-service.js
+++ b/addon/instance-initializers/router-service.js
@@ -11,11 +11,12 @@ export function initialize(appInstance) {
   let { application } = appInstance;
   let fullName = 'service:router';
   let router = lookupSource.lookup('router:main');
+  let registerOptions = { singleton: true, instantiate: false };
   // use application for ember 1.13
   if (application.hasRegistration) {
-    appInstance.register(fullName, router, { singleton: true, instantiate: false });
+    appInstance.register(fullName, router, registerOptions);
   } else {
-    application.register(fullName, router, { singleton: true, instantiate: false });
+    application.register(fullName, router, registerOptions);
   }
 
 }

--- a/addon/instance-initializers/router-service.js
+++ b/addon/instance-initializers/router-service.js
@@ -8,21 +8,9 @@ export function initialize(appInstance) {
     lookupSource = appInstance.container;
   }
 
-  let { application } = appInstance;
-  let fullName = 'service:router';
-  
-  let registerSource;
-
-  // use application for ember 1.13
-  if (application.hasRegistration) {
-    registerSource = appInstance;
-  } else {
-    registerSource = application;
-  }
-
   let router = lookupSource.lookup('router:main');
 
-  registerSource.register(fullName, router, { singleton: true, instantiate: false });
+  appInstance.register('service:router', router, { singleton: true, instantiate: false });
 }
 
 export default {

--- a/addon/instance-initializers/router-service.js
+++ b/addon/instance-initializers/router-service.js
@@ -1,16 +1,19 @@
 export function initialize(appInstance) {
   let lookupSource;
+  let registerSource;
 
   if (appInstance.lookup) {
     lookupSource = appInstance;
+    registerSource = appInstance;
   } else {
     // ember 1.13 support
     lookupSource = appInstance.container;
+    registerSource = appInstance.application;
   }
 
   let router = lookupSource.lookup('router:main');
 
-  appInstance.register('service:router', router, { singleton: true, instantiate: false });
+  registerSource.register('service:router', router, { singleton: true, instantiate: false });
 }
 
 export default {

--- a/addon/instance-initializers/router-service.js
+++ b/addon/instance-initializers/router-service.js
@@ -10,18 +10,14 @@ export function initialize(appInstance) {
 
   let { application } = appInstance;
   let fullName = 'service:router';
-
-  // skip fastboot check if ember 1.13
+  let router = lookupSource.lookup('router:main');
+  // use application for ember 1.13
   if (application.hasRegistration) {
-    // fastboot support
-    if (application.hasRegistration(fullName)) {
-      return;
-    }
+    appInstance.register(fullName, router, { singleton: true, instantiate: false });
+  } else {
+    application.register(fullName, router, { singleton: true, instantiate: false });
   }
 
-  let router = lookupSource.lookup('router:main');
-
-  application.register(fullName, router, { singleton: true, instantiate: false });
 }
 
 export default {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "^0.5.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/unit/instance-initializers/router-service-test.js
+++ b/tests/unit/instance-initializers/router-service-test.js
@@ -55,12 +55,12 @@ test('ensure register is called for 1.13', function(assert) {
   }
   let register = sinon.spy();
   let appInstance = {
-      container: {
-          lookup: sinon.stub().returns({}),
-      },
-      application: {
-          register: register
-      }
+    container: {
+      lookup: sinon.stub().returns({}),
+    },
+    application: {
+      register: register
+    }
   };
   initialize(appInstance);
   assert.ok(register.calledOnce);
@@ -74,11 +74,8 @@ test('ensure register is called for 2.x', function(assert) {
   }
   let register = sinon.spy();
   let appInstance = {
-      lookup: sinon.stub().returns({}),
-      register: register,
-      application: {
-          hasRegistration: sinon.stub().returns({})
-      }
+    lookup: sinon.stub().returns({}),
+    register: register
   };
   initialize(appInstance);
   assert.ok(register.calledOnce);

--- a/tests/unit/instance-initializers/router-service-test.js
+++ b/tests/unit/instance-initializers/router-service-test.js
@@ -49,25 +49,30 @@ test('doesn\'t error when run multiple times (fastboot support)', function(asser
 
 test('ensure register is called for 1.13', function(assert) {
   let register = sinon.spy();
+
   let appInstance = {
     container: {
       lookup: sinon.stub().returns({}),
     },
     application: {
-      register: register
+      register
     }
   };
+
   initialize(appInstance);
+
   assert.ok(register.calledOnce);
 });
 
 test('ensure register is called for 2.x', function(assert) {
-
   let register = sinon.spy();
+
   let appInstance = {
     lookup: sinon.stub().returns({}),
-    register: register
+    register
   };
+
   initialize(appInstance);
+
   assert.ok(register.calledOnce);
 });

--- a/tests/unit/instance-initializers/router-service-test.js
+++ b/tests/unit/instance-initializers/router-service-test.js
@@ -47,16 +47,37 @@ test('doesn\'t error when run multiple times (fastboot support)', function(asser
   assert.ok(this.appInstance.hasRegistration('service:router'));
 });
 
-test('ensure register is called for 1.13 and 2.x', function(assert) {
+test('ensure register is called for 1.13', function(assert) {
+  if (this.appInstance.hasRegistration) {
+    // skip fastboot check if ember 1.13
+    assert.ok(true);
+    return;
+  }
   let register = sinon.spy();
   let appInstance = {
-      lookup: sinon.stub().returns({}),
-      register: register,
       container: {
           lookup: sinon.stub().returns({}),
       },
       application: {
           register: register
+      }
+  };
+  initialize(appInstance);
+  assert.ok(register.calledOnce);
+});
+
+test('ensure register is called for 2.x', function(assert) {
+  if (!this.appInstance.hasRegistration) {
+    // skip fastboot check if ember 1.13
+    assert.ok(true);
+    return;
+  }
+  let register = sinon.spy();
+  let appInstance = {
+      lookup: sinon.stub().returns({}),
+      register: register,
+      application: {
+          hasRegistration: sinon.stub().returns({})
       }
   };
   initialize(appInstance);

--- a/tests/unit/instance-initializers/router-service-test.js
+++ b/tests/unit/instance-initializers/router-service-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { initialize } from 'dummy/instance-initializers/router-service';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import sinon from 'sinon';
 
 module('Unit | Instance Initializer | router service', {
   beforeEach: function() {
@@ -44,4 +45,20 @@ test('doesn\'t error when run multiple times (fastboot support)', function(asser
   initialize(this.appInstance);
 
   assert.ok(this.appInstance.hasRegistration('service:router'));
+});
+
+test('ensure register is called for 1.13 and 2.x', function(assert) {
+  let register = sinon.spy();
+  let appInstance = {
+      lookup: sinon.stub().returns({}),
+      register: register,
+      container: {
+          lookup: sinon.stub().returns({}),
+      },
+      application: {
+          register: register
+      }
+  };
+  initialize(appInstance);
+  assert.ok(register.calledOnce);
 });

--- a/tests/unit/instance-initializers/router-service-test.js
+++ b/tests/unit/instance-initializers/router-service-test.js
@@ -48,11 +48,6 @@ test('doesn\'t error when run multiple times (fastboot support)', function(asser
 });
 
 test('ensure register is called for 1.13', function(assert) {
-  if (this.appInstance.hasRegistration) {
-    // skip fastboot check if ember 1.13
-    assert.ok(true);
-    return;
-  }
   let register = sinon.spy();
   let appInstance = {
     container: {
@@ -67,11 +62,7 @@ test('ensure register is called for 1.13', function(assert) {
 });
 
 test('ensure register is called for 2.x', function(assert) {
-  if (!this.appInstance.hasRegistration) {
-    // skip fastboot check if ember 1.13
-    assert.ok(true);
-    return;
-  }
+
   let register = sinon.spy();
   let appInstance = {
     lookup: sinon.stub().returns({}),


### PR DESCRIPTION
When using fastboot, the router service is only present for the first request, and afterwards is `undefined`.

Instead of returning early, we should use `appInstance.register` for Ember 2.x, use `appInstance.application.register` for Ember 1.13.